### PR TITLE
Remove redundant api fields

### DIFF
--- a/npsat_backend/local_settings_template.py
+++ b/npsat_backend/local_settings_template.py
@@ -31,6 +31,11 @@ SERVER_EMAIL = ''  # what address does the email come from?
 MANTIS_STATUS_MESSAGE = "status"
 MANTIS_STATUS_RESPONSE = "online"
 
+# Admin bot
+# change the string in deployment
+ADMIN_BOT_USERNAME = "TEMPLATE_ADMIN_USERNAME"
+ADMIN_BOT_PASSWORD = "TEMPLATE_ADMIN_PASSWORD"
+
 StartYear = 1945  # When to start the curves off
 EndYear = 2065  # What's the max year to calculate until?
 ChangeYear = 2020  # When do we actually start trying to get a reduction?

--- a/npsat_manager/load_data.py
+++ b/npsat_manager/load_data.py
@@ -5,6 +5,8 @@ import json
 from npsat_backend import settings
 
 from npsat_manager import models
+from django.contrib.auth.models import User
+from npsat_backend import local_settings
 
 data_folder = os.path.join(settings.BASE_DIR, "npsat_manager", "data")
 
@@ -14,6 +16,11 @@ def load_all(mantis_port_number=5941):
 	load_regions()
 	load_scenarios()
 	load_mantis_server(mantis_port_number=mantis_port_number)
+	load_system_admin_bot()
+
+
+def load_system_admin_bot():
+	User.objects.create(username=local_settings.ADMIN_BOT_USERNAME, password=local_settings.ADMIN_BOT_PASSWORD)
 
 
 def load_scenarios():

--- a/npsat_manager/serializers.py
+++ b/npsat_manager/serializers.py
@@ -160,11 +160,17 @@ class RunResultSerializer(serializers.ModelSerializer):
 				  'reduction_start_year', 'reduction_end_year', 'is_base', 'results', 'n_wells', 'public',
 				  'load_scenario', 'flow_scenario', 'unsat_scenario')
 		depth = 0  # should mean that modifications get included in the initial request
+		extra_kwargs = {
+			"user": {
+				"required": False
+			}
+		}
 
 	def validate(self, data):
 		return data
 
 	def create(self, validated_data):
+		user = self.context["user"]
 		regions_data = validated_data.pop('regions')
 		modifications_data = validated_data.pop('modifications')
 		unsat_scenario = validated_data.pop('unsat_scenario')
@@ -172,6 +178,7 @@ class RunResultSerializer(serializers.ModelSerializer):
 		flow_scenario = validated_data.pop('flow_scenario')
 
 		model_run = models.ModelRun.objects.create(**validated_data,
+												   user=user,
 												   unsat_scenario=models.Scenario.objects.get(id=unsat_scenario['id']),
 												   flow_scenario=models.Scenario.objects.get(id=flow_scenario['id']),
 												   load_scenario=models.Scenario.objects.get(id=load_scenario['id']),

--- a/npsat_manager/tests/test_APIs.py
+++ b/npsat_manager/tests/test_APIs.py
@@ -21,6 +21,7 @@ class APITestCase(TestCase):
     Test for all APIs:
         single operation tests
     """
+
     @classmethod
     def setUpTestData(cls):
         """set up common resources and some fake users/models"""
@@ -150,6 +151,7 @@ class APITestCase(TestCase):
         1. Serializers are tested by Django. We will only check if some fields are correctly
             outputted in the response
     """
+
     def test_model_run_read(self):
         """
         Test read in model run endpoints.
@@ -271,7 +273,6 @@ class APITestCase(TestCase):
         # test access
         data = {
             "name": "Test Model Run POST endpoint 1",
-            "user": user1.id,
             "modifications": [
                 {
                     "crop": {
@@ -306,8 +307,7 @@ class APITestCase(TestCase):
         client_logged_in.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
 
         res = client_logged_in.post("/api/model_run/", data, format="json")
-        self.assertEqual(res.status_code, 403)
-
+        self.assertEqual(res.status_code, 201)
 
     def test_model_run_delete(self):
         """
@@ -385,9 +385,9 @@ class StimulationAPITest(TestCase):
     """
     Stimulate front end queries
     """
+
     @classmethod
     def setUpTestData(cls):
         utils.load_resources(0.5)
         utils.load_test_users()
         utils.load_default_model_runs()
-

--- a/npsat_manager/views.py
+++ b/npsat_manager/views.py
@@ -43,13 +43,6 @@ class ModifyAccessPermission(BasePermission):
 	"""
 	This permission is particularly defined for model run
 	"""
-	def has_permission(self, request, view):
-		# it defines a special case for POST request
-		if request.method == "POST":
-			# user can only create model for oneself
-			return request.data["user"] == request.user.id or request.user.is_staff
-		return True
-
 	def has_object_permission(self, request, view, obj):
 		if request.method not in SAFE_METHODS:
 			return request.user == obj.user
@@ -195,6 +188,11 @@ class ModelRunViewSet(viewsets.ModelViewSet):
 	permission_classes = [IsAuthenticated & ModifyAccessPermission]
 	http_method_names = ['get', 'post', 'put', 'delete', 'head', 'options']
 	serializer_class = serializers.RunResultSerializer
+
+	def get_serializer_context(self):
+		context = super(ModelRunViewSet, self).get_serializer_context()
+		context.update({"user": self.request.user})
+		return context
 
 	def retrieve(self, request, *args, **kwargs):
 		serializer = None


### PR DESCRIPTION
remove `user` field in `POST` method, and remove the redundant security check